### PR TITLE
修复火山引擎转录鉴权并兼容新版识别接口

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+VOLCENGINE_API_KEY=your_api_key_here
+
+# Optional: official v1 audio/video caption API
+# https://www.volcengine.com/docs/6561/80909
+VOLCENGINE_APPID=your_appid_here
+VOLCENGINE_ACCESS_TOKEN=your_access_token_here

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ git clone https://github.com/Ceeon/videocut-skills.git ~/.claude/skills/videocut
 cd ~/.claude/skills/videocut
 cp .env.example .env
 # 编辑 .env，填入火山引擎 API Key
+#
+# 新版控制台：
+# VOLCENGINE_API_KEY=xxx
+#
+# 音视频字幕生成 v1（https://www.volcengine.com/docs/6561/80909）：
+# VOLCENGINE_APPID=xxx
+# VOLCENGINE_ACCESS_TOKEN=xxx
 ```
 
 ### 3. 安装环境

--- a/剪口播/SKILL.md
+++ b/剪口播/SKILL.md
@@ -298,4 +298,8 @@ node "$SKILL_DIR/scripts/review_server.js" 8899 "$VIDEO_PATH"
 cd /Users/chengfeng/Desktop/AIos/剪辑Agent/.claude/skills
 cp .env.example .env
 # 编辑 .env 填入 VOLCENGINE_API_KEY=xxx
+#
+# 如使用音视频字幕生成 v1：
+# VOLCENGINE_APPID=xxx
+# VOLCENGINE_ACCESS_TOKEN=xxx
 ```

--- a/剪口播/scripts/generate_subtitles.js
+++ b/剪口播/scripts/generate_subtitles.js
@@ -23,8 +23,10 @@ const allWords = [];
 for (const utterance of result.utterances) {
   if (utterance.words) {
     for (const word of utterance.words) {
+      if (word.start_time < 0 || word.end_time < 0) continue;
+      if (!word.text || !word.text.trim()) continue;
       allWords.push({
-        text: word.text,
+        text: word.text.trim(),
         start: word.start_time / 1000,
         end: word.end_time / 1000
       });

--- a/剪口播/scripts/volcengine_transcribe.sh
+++ b/剪口播/scripts/volcengine_transcribe.sh
@@ -13,7 +13,7 @@ if [ -z "$AUDIO_URL" ]; then
   exit 1
 fi
 
-# 获取 API Key
+# 获取 API 配置
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENV_FILE="$(dirname "$(dirname "$SCRIPT_DIR")")/.env"
 
@@ -23,7 +23,10 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
-API_KEY=$(grep VOLCENGINE_API_KEY "$ENV_FILE" | cut -d'=' -f2)
+API_KEY=$(grep '^VOLCENGINE_API_KEY=' "$ENV_FILE" | head -1 | cut -d'=' -f2-)
+APPID=$(grep '^VOLCENGINE_APPID=' "$ENV_FILE" | head -1 | cut -d'=' -f2-)
+ACCESS_TOKEN=$(grep '^VOLCENGINE_ACCESS_TOKEN=' "$ENV_FILE" | head -1 | cut -d'=' -f2-)
+TOKEN="${ACCESS_TOKEN:-$API_KEY}"
 
 echo "🎤 提交火山引擎转录任务..."
 echo "音频 URL: $AUDIO_URL"
@@ -45,12 +48,53 @@ else
 fi
 
 # 步骤1: 提交任务
-SUBMIT_RESPONSE=$(curl -s -L -X POST "https://openspeech.bytedance.com/api/v1/vc/submit?language=zh-CN&use_itn=True&use_capitalize=True&max_lines=1&words_per_line=15" \
-  -H "Accept: */*" \
-  -H "x-api-key: $API_KEY" \
-  -H "Connection: keep-alive" \
-  -H "content-type: application/json" \
-  -d "$REQUEST_BODY")
+if [ -n "$APPID" ] && [ -n "$TOKEN" ]; then
+  # 官方音视频字幕生成 v1:
+  # https://www.volcengine.com/docs/6561/80909
+  SUBMIT_RESPONSE=$(curl -s -L -X POST "https://openspeech.bytedance.com/api/v1/vc/submit?appid=$APPID&language=zh-CN&use_itn=True&use_capitalize=True&max_lines=1&words_per_line=15" \
+    -H "Accept: */*" \
+    -H "Authorization: Bearer; $TOKEN" \
+    -H "Connection: keep-alive" \
+    -H "content-type: application/json" \
+    -d "$REQUEST_BODY")
+else
+  # 新版控制台 API Key：录音文件极速版识别。
+  # 返回结构不同，这里转换成后续脚本使用的 volcengine_result.json。
+  REQ_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+  FLASH_BODY="{\"user\":{\"uid\":\"videocut\"},\"audio\":{\"url\":\"$AUDIO_URL\"},\"request\":{\"model_name\":\"bigmodel\"}}"
+  FLASH_HEADERS=$(mktemp)
+  FLASH_RESPONSE=$(curl -s -D "$FLASH_HEADERS" -L -X POST "https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash" \
+    -H "X-Api-Key: $API_KEY" \
+    -H "X-Api-Resource-Id: volc.bigasr.auc_turbo" \
+    -H "X-Api-Request-Id: $REQ_ID" \
+    -H "X-Api-Sequence: -1" \
+    -H "content-type: application/json" \
+    -d "$FLASH_BODY")
+  FLASH_STATUS=$(awk 'BEGIN{IGNORECASE=1}/^X-Api-Status-Code:/{gsub("\r",""); print $2}' "$FLASH_HEADERS" | tail -1)
+  rm -f "$FLASH_HEADERS"
+  echo "$FLASH_RESPONSE" | FLASH_REQ_ID="$REQ_ID" FLASH_STATUS="$FLASH_STATUS" node -e "
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf8');
+const flash = JSON.parse(input);
+const ok = process.env.FLASH_STATUS === '20000000' || (flash.result && Array.isArray(flash.result.utterances));
+if (!ok) process.exit(1);
+const converted = {
+  id: process.env.FLASH_REQ_ID,
+  code: 0,
+  message: 'Success',
+  utterances: flash.result?.utterances || [],
+  text: flash.result?.text || '',
+  audio_info: flash.audio_info || {}
+};
+fs.writeFileSync('volcengine_result.json', JSON.stringify(converted, null, 2));
+console.log('✅ 转录完成，已保存 volcengine_result.json');
+console.log('📝 识别到 ' + converted.utterances.length + ' 段语音');
+"
+  if [ $? -eq 0 ]; then
+    exit 0
+  fi
+  SUBMIT_RESPONSE="$FLASH_RESPONSE"
+fi
 
 # 提取任务 ID
 TASK_ID=$(echo "$SUBMIT_RESPONSE" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
@@ -72,9 +116,9 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
   sleep 5
   ATTEMPT=$((ATTEMPT + 1))
 
-  QUERY_RESPONSE=$(curl -s -L -X GET "https://openspeech.bytedance.com/api/v1/vc/query?id=$TASK_ID" \
+  QUERY_RESPONSE=$(curl -s -L -X GET "https://openspeech.bytedance.com/api/v1/vc/query?appid=$APPID&id=$TASK_ID" \
     -H "Accept: */*" \
-    -H "x-api-key: $API_KEY" \
+    -H "Authorization: Bearer; $TOKEN" \
     -H "Connection: keep-alive")
 
   # 检查状态

--- a/安装/SKILL.md
+++ b/安装/SKILL.md
@@ -40,13 +40,17 @@ pos: 前置 skill，首次使用前运行
 
 1. 注册火山引擎账号
 2. 开通语音识别服务
-3. 获取 API Key
+3. 获取 API Key；如使用音视频字幕生成 v1，还需获取 AppID 和 Access Token
 
 配置到项目目录 `.claude/skills/.env`：
 
 ```bash
 # 文件路径：剪辑Agent/.claude/skills/.env
 VOLCENGINE_API_KEY=your_api_key_here
+
+# 可选：音视频字幕生成 v1
+VOLCENGINE_APPID=your_appid_here
+VOLCENGINE_ACCESS_TOKEN=your_access_token_here
 ```
 
 ## 安装流程
@@ -77,6 +81,10 @@ ffmpeg -version
 ```bash
 # 在项目 .claude/skills/ 目录下创建 .env 文件
 echo "VOLCENGINE_API_KEY=your_key" >> .claude/skills/.env
+
+# 如果使用音视频字幕生成 v1：
+echo "VOLCENGINE_APPID=your_appid" >> .claude/skills/.env
+echo "VOLCENGINE_ACCESS_TOKEN=your_access_token" >> .claude/skills/.env
 ```
 
 ### 3. 验证环境


### PR DESCRIPTION
## 摘要

- 按官方文档修复火山引擎音视频字幕生成 v1 接口鉴权：使用 `appid` 查询参数和 `Authorization: Bearer; token` 请求头
- 增加新版控制台 `X-Api-Key` 极速识别接口兜底支持，资源 ID 为 `volc.bigasr.auc_turbo`，并把返回结果转换成原流程需要的 `volcengine_result.json`
- 修复新版识别结果中英文空格 token 的 `start_time=-1` / `end_time=-1` 导致假静音暴增的问题
- 新增 `.env.example`，补充 `VOLCENGINE_API_KEY`、`VOLCENGINE_APPID`、`VOLCENGINE_ACCESS_TOKEN` 配置说明
- 更新 README、安装 skill、剪口播 skill 中的环境变量说明

## 验证

- 已执行 `bash -n 剪口播/scripts/volcengine_transcribe.sh`
- 已执行 `node --check 剪口播/scripts/generate_subtitles.js`
- 已用公开 mp3 URL 对新版极速识别接口做 smoke test，转录成功
- `generate_subtitles.js` 生成结果为 208 个元素、63 个静音段、0 个负时间戳

参考文档：https://www.volcengine.com/docs/6561/80909?lang=zh