### PR TITLE
Fix Runtime preflight and AI terminology

### DIFF
--- a/plugins/chengfeng-videocut/.codex-plugin/plugin.json
+++ b/plugins/chengfeng-videocut/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chengfeng-videocut",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Four task-facing chengfeng-videocut Skills: two talking-head workflows, safe bug reporting, and Marketplace update checks. Shared product boundaries are internal references, not a user-facing Skill.",
   "author": {
     "name": "Chengfeng",

--- a/plugins/chengfeng-videocut/README.md
+++ b/plugins/chengfeng-videocut/README.md
@@ -41,13 +41,13 @@ $chengfeng-videocut:chengfeng-check-videocut-updates
 
 共同边界只存在于 `references/runtime-and-product-contract.md` 与 `references/business-workflow-contract.md`。普通 reference 没有 `SKILL.md`、公开 ID 或 UI 卡片，不占用用户入口。
 
-两个业务 Skill 共用 `scripts/ensure-runtime.cjs`、`scripts/ensure-running.cjs` 和 `runtime-requirements.json`。Plugin package `0.5.1` 消费 Runtime compatibility contract `0.2.0`：只接受 Runtime 0.2.0+ 与声明的 EDL、常驻 service 能力；缺失时从精确的 `v0.2.0` Release 获取安装器和校验清单，校验后安装并执行 doctor。随后由 Product `service ensure --json` 幂等安装或恢复 macOS 用户服务；Plugin 不直接使用 `launchctl`、`nohup` 或 foreground 后台进程。Release 不存在、资产不完整或服务身份不匹配时安全停止，不会安装或覆盖旧 Runtime。Studio 只在人工审核状态且通过 `ensure-studio.cjs` 顶层视图能力门禁后打开。
+两个业务 Skill 共用 `scripts/ensure-runtime.cjs`、`scripts/ensure-running.cjs` 和 `runtime-requirements.json`。Plugin package `0.5.2` 消费 Runtime compatibility contract `0.2.1`：只接受 Runtime 0.2.1+ 与声明的 EDL、常驻 service、逐词稿操作能力；缺失时从精确的 `v0.2.1` Release 获取安装器和校验清单，校验后安装并执行 doctor。随后由 Product `service ensure --json` 幂等安装或恢复 macOS 用户服务；Plugin 不直接使用 `launchctl`、`nohup` 或 foreground 后台进程。Release 不存在、资产不完整或服务身份不匹配时安全停止，不会安装或覆盖旧 Runtime。Studio 只在人工审核状态且通过 `ensure-studio.cjs` 顶层视图能力门禁后打开。
 
 `chengfeng-report-videocut-bug` 不安装 Runtime、不启动 Studio，也不改项目。它只生成脱敏 Issue 草稿，用户确认同一份正文后才调用 GitHub CLI；没有明确 Issue URL 就不宣称上报成功。
 
 `chengfeng-check-videocut-updates` 的 `--inspect` 不 refresh；用户明确说检查更新后，它只对 Git Marketplace 运行官方 `codex plugin marketplace upgrade` 并比较 installed/available。本地 Marketplace 返回 `marketplace_not_refreshable`。官方 CLI 没有独立 stage：refresh 后的 snapshot 是唯一检查来源。激活前必须有 40-hex immutable commit、发布者 SHA-256 与 snapshot 内可重算的同一包清单哈希；裸 semver/tag 一律不可信。当前公开基线缺这些证明时返回 `update_metadata_untrusted`，不下载、不调用 `plugin add`。用户明确确认且传回所见 version/ref/SHA-256 后才以官方 `codex plugin add` 激活；随后必须从 installed cache 复读 version/ref/checksum 并重算 bundle inventory digest，任一不可观察或不一致即 `plugin_activation_unsupported`。失败绝不删除 cache、复制目录或更新 Runtime/项目。
 
-Plugin 是独立的 `0.5.1` 版本；`runtime-requirements.json` 仍要求 Product Runtime `0.2.0`。两者不能互相替代。
+Plugin 是独立的 `0.5.2` 版本；`runtime-requirements.json` 仍要求 Product Runtime `0.2.1`。两者不能互相替代。
 
 ## 开发验证
 

--- a/plugins/chengfeng-videocut/dist/server.mjs
+++ b/plugins/chengfeng-videocut/dist/server.mjs
@@ -3,25 +3,43 @@ var __getProtoOf = Object.getPrototypeOf;
 var __defProp = Object.defineProperty;
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
+function __accessProp(key) {
+  return this[key];
+}
+var __toESMCache_node;
+var __toESMCache_esm;
 var __toESM = (mod, isNodeMode, target) => {
+  var canCache = mod != null && typeof mod === "object";
+  if (canCache) {
+    var cache = isNodeMode ? __toESMCache_node ??= new WeakMap : __toESMCache_esm ??= new WeakMap;
+    var cached = cache.get(mod);
+    if (cached)
+      return cached;
+  }
   target = mod != null ? __create(__getProtoOf(mod)) : {};
   const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
   for (let key of __getOwnPropNames(mod))
     if (!__hasOwnProp.call(to, key))
       __defProp(to, key, {
-        get: () => mod[key],
+        get: __accessProp.bind(mod, key),
         enumerable: true
       });
+  if (canCache)
+    cache.set(mod, to);
   return to;
 };
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+var __returnValue = (v) => v;
+function __exportSetter(name, newValue) {
+  this[name] = __returnValue.bind(null, newValue);
+}
 var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, {
       get: all[name],
       enumerable: true,
       configurable: true,
-      set: (newValue) => all[name] = () => newValue
+      set: __exportSetter.bind(all, name)
     });
 };
 
@@ -6371,7 +6389,7 @@ var require_formats = __commonJS((exports) => {
   }
   var TIME = /^(\d\d):(\d\d):(\d\d(?:\.\d+)?)(z|([+-])(\d\d)(?::?(\d\d))?)?$/i;
   function getTime(strictTimeZone) {
-    return function time(str) {
+    return function time3(str) {
       const matches = TIME.exec(str);
       if (!matches)
         return false;
@@ -14003,7 +14021,7 @@ class JSONSchemaGenerator {
               if (val === undefined) {
                 if (this.unrepresentable === "throw") {
                   throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-                } else {}
+                }
               } else if (typeof val === "bigint") {
                 if (this.unrepresentable === "throw") {
                   throw new Error("BigInt literals cannot be represented in JSON Schema");
@@ -27302,7 +27320,7 @@ var optionSchema = exports_external.object({
   description: exports_external.string(),
   nextStep: exports_external.string()
 });
-var server = new McpServer({ name: "chengfeng-videocut", version: "0.5.1" });
+var server = new McpServer({ name: "chengfeng-videocut", version: "0.5.2" });
 ak(server, "workflow-confirm-card", templateUri, {}, async () => ({
   contents: [{
     uri: templateUri,

--- a/plugins/chengfeng-videocut/package-lock.json
+++ b/plugins/chengfeng-videocut/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chengfeng-videocut-codex-plugin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chengfeng-videocut-codex-plugin",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "1.0.1",
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/plugins/chengfeng-videocut/package.json
+++ b/plugins/chengfeng-videocut/package.json
@@ -1,11 +1,11 @@
 {
   "name": "chengfeng-videocut-codex-plugin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "scripts": {
     "build": "bun build server.mjs --target=node --format=esm --outfile=dist/server.mjs",
-    "test": "node scripts/runtime-preflight.test.cjs && node scripts/ensure-running.test.cjs && node scripts/studio-capability.test.cjs && node scripts/bug-report.test.cjs && node scripts/skill-paths.test.cjs && node scripts/business-workflow-contract.test.cjs && node scripts/check-plugin-update.test.cjs && node scripts/mcp-smoke-test.mjs"
+    "test": "node scripts/runtime-preflight.test.cjs && node scripts/ensure-running.test.cjs && node scripts/studio-capability.test.cjs && node scripts/bug-report.test.cjs && node scripts/skill-paths.test.cjs && node scripts/business-workflow-contract.test.cjs && node scripts/ai-term-dictionary.test.cjs && node scripts/check-plugin-update.test.cjs && node scripts/mcp-smoke-test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "1.0.1",

--- a/plugins/chengfeng-videocut/references/ai-term-dictionary.md
+++ b/plugins/chengfeng-videocut/references/ai-term-dictionary.md
@@ -33,33 +33,39 @@
 | 正确写法 | 常见误识别 |
 | --- | --- |
 | Grok | grok / Clock / Glock / Gokul / Croc / 格罗克 |
-| Codex | CodeX / codex / Code X / codecs |
+| Codex | CodeX / codex / Code X / codecs / Codax |
 | Claude | claude / Cloud / Clode / 克劳德 |
-| ChatGPT | chatgpt / Chat GPT / GPT / 聊天 GPT |
+| ChatGPT | chatgpt / Chat GPT |
 | GPT-4 | GPT4 / gpt 4 / GBT4 |
 | Gemini | gemini / Germany / 双子星 |
-| DeepSeek | deepseek / Deep Seek / 深度求索 |
-| Qwen | qwen / Q1 / 千问 / 通义千问 |
+| DeepSeek | deepseek / Deep Seek |
+| Qwen | qwen |
 | Kimi | kimi / KIMI |
 | Sora | sora / 索拉 |
 | Midjourney | midjourney / Mid Journey / MJ |
-| Cursor | cursor / 光标 |
-| Copilot | copilot / Co-pilot / 副驾驶 |
+| Cursor | cursor |
+| Copilot | copilot / Co-pilot |
 
 ### 术语
 
 | 正确写法 | 常见误识别 |
 | --- | --- |
-| Agent | agent / 代理 / 智能体（保留原文时不换） |
-| CLI | cli / C L I / 命令行 |
+| Agent | agent |
+| CLI | cli / C L I |
 | API | api / A P I |
 | MCP | mcp / M C P |
-| Prompt | prompt / 提示词（保留原文时不换） |
-| Token | token / 令牌 |
+| Prompt | prompt |
+| Token | token |
 | RAG | rag / R A G |
-| LLM | llm / L L M / 大模型 |
-| Skill | skill / 技能 |  <!-- 「Skills」是 Claude Skills 的复数专名，说话人真会这么说，不许换 -->
-| Workflow | workflow / 工作流 |
+| LLM | llm / L L M |
+| Skill | skill |  <!-- 「Skills」是 Claude Skills 的复数专名，说话人真会这么说，不许换 -->
+| Workflow | workflow |
+| TTS | tts / T T S |
+| ASR | asr / A S R |
+| Runtime | runtime / Run Time |
+| Artifact | artifact |
+| B-roll | B roll / Broll / b-roll |
+| Markdown | markdown / Mark Down |
 
 ### 公司与平台
 
@@ -69,8 +75,22 @@
 | Anthropic | anthropic / 安索匹克 |
 | xAI | XAI / x AI |
 | GitHub | github / Git Hub / 吉特哈布 |
-| Hugging Face | huggingface / Hugging face / 抱抱脸 |
-| X | 叉 / 推特 / Twitter（说话人说「叉」时按原文保留，不换） |
+| Hugging Face | huggingface / Hugging face |
+
+### 当前作者知识库高频专名
+
+这些词来自已授权的 Obsidian `Creator Studio` Markdown 统计，只收录能确认的正式写法及
+大小写、空格变体。词频只能证明“值得收录”，不能证明任意谐音就是它，因此没有证据的
+误识别不写进词典。
+
+| 正确写法 | 常见误识别 |
+| --- | --- |
+| Obsidian | obsidian |
+| HyperFrames | Hyperframes / hyperframes / Hyper Frames |
+| Chengfeng | chengfeng / Cheng Feng |
+| TikHub | Tikhub / tikhub / Tik Hub |
+| Creator Studio | CreatorStudio / creator studio |
+| Video Maker | VideoMaker / video maker |
 
 ## 中文口语按原文保留，不要「纠正」
 

--- a/plugins/chengfeng-videocut/references/runtime-and-product-contract.md
+++ b/plugins/chengfeng-videocut/references/runtime-and-product-contract.md
@@ -26,12 +26,12 @@ ensure-runtime
                                       停止，不回退旧剪辑链
 ```
 
-- Plugin package `0.5.1` 消费的机器可读 Runtime compatibility contract 是 `runtime-requirements.json`：`releaseTag=v0.2.0`、`releaseVersion=0.2.0`、最低 Runtime 为 `0.2.0`，并声明 Runtime EDL 与 Studio 能力集合。
-- 缺失时只从 `v0.2.0` 的精确 Release 下载 `install.sh` 与 `SHA256SUMS.txt`；先校验安装器本身，再执行安装器。安装器收到同一个精确 Release 地址，不得访问 `latest`。
-- `v0.2.0` Release 尚不存在、缺少安装器、缺少安装器校验值或哈希不符时，以 `install_failed` 停止；不得转装公开旧版、源码 clone、npm、bunx 或 DMG。
+- Plugin package `0.5.2` 消费的机器可读 Runtime compatibility contract 是 `runtime-requirements.json`：`releaseTag=v0.2.1`、`releaseVersion=0.2.1`、最低 Runtime 为 `0.2.1`，并声明 Runtime EDL 与 Studio 能力集合。
+- 缺失时只从 `v0.2.1` 的精确 Release 下载 `install.sh` 与 `SHA256SUMS.txt`；先校验安装器本身，再执行安装器。安装器收到同一个精确 Release 地址，不得访问 `latest`。
+- `v0.2.1` Release 尚不存在、缺少安装器、缺少安装器校验值或哈希不符时，以 `install_failed` 停止；不得转装公开旧版、源码 clone、npm、bunx 或 DMG。
 - 安装位置是 `CHENGFENG_VIDEOCUT_HOME` 或 `~/.chengfeng-videocut`。
-- CLI 已存在但 doctor 失败时不自动覆盖或循环重装；已有 Runtime 低于 0.2.0 时也不静默覆盖。
-- CLI doctor 健康但版本低于 0.2.0，或缺少 EDL schema、expected revision、managed A-roll projection、move / trim / split / delete、service API、父进程独立存活或 crash restart capability 时，以 `runtime_capability_missing` 停止；不把“健康”误当“兼容”。
+- CLI 已存在但 doctor 失败时不自动覆盖或循环重装；已有 Runtime 低于 0.2.1 时也不静默覆盖。
+- CLI doctor 健康但版本低于 0.2.1，或缺少 EDL schema、expected revision、managed A-roll projection、move / trim / split / delete、service API、父进程独立存活、crash restart，以及 `playback / retranscribe / align / dictionary / regroup / correct` 任一逐词稿操作 capability 时，以 `runtime_capability_missing` 停止；不把“健康”误当“兼容”。
 - 查找顺序：显式 `CHENGFENG_VIDEOCUT_BIN`、PATH、托管安装目录、显式开发目录 `CHENGFENG_VIDEOCUT_DIR`。
 - 不使用 npm、bunx、DMG 或源码 clone 作为普通用户安装流程。
 
@@ -50,7 +50,7 @@ Product service ensure --json
 ```
 
 - Plugin 不直接调用 `launchctl`、`nohup`、PID 文件或后台进程 API；服务安装、启动、升级收敛和 crash restart 全部属于 Product。
-- `service ensure` 成功必须返回 `ok=true`，且 `data` 同时满足：`healthy=true`、`runtimeMode=launchd`、`productVersion>=0.2.0`、正整数 `pid`、`url=http://127.0.0.1:5190/`。
+- `service ensure` 成功必须返回 `ok=true`，且 `data` 同时满足：`healthy=true`、`runtimeMode=launchd`、`productVersion>=0.2.1`、正整数 `pid`、`url=http://127.0.0.1:5190/`。
 - 健康服务会幂等复用；页面或 Codex 父终端关闭不应结束服务。
 - 返回 foreground 身份、未知端口占用、错误 URL、旧版本或不完整 JSON 时 fail-closed；Skill 不杀进程、不换 5191、不回退临时 foreground。
 - `service ensure` 不创建项目、不打开 Studio；仍只在 `*_review_ready` 后执行 `open`。
@@ -104,17 +104,18 @@ Product open 返回项目 URL
 
 ## 当前 Runtime 兼容门禁
 
-- 公开 Runtime v0.1.1 不具备 Plugin package `0.5.1` 所消费的完整 EDL / Studio compatibility contract，必须被版本与能力门禁拒绝。
-- Runtime `v0.2.0` Release 必须先于 Plugin package `0.5.1` 发布，并至少包含 `install.sh`、`chengfeng-videocut-portable.tar.gz` 与覆盖两者的 `SHA256SUMS.txt`。
-- `v0.2.0` 必须提供正式原视频云端转录命令；缺少时以 `missing_cloud_transcription_adapter` 停止，禁止回退本地 ASR。
-- `v0.2.0` 必须内置可用 renderer；新版 Skill 不得把旧 renderer 重新打包。
+- 公开 Runtime v0.1.1 不具备 Plugin package `0.5.2` 所消费的完整 EDL / Studio compatibility contract，必须被版本与能力门禁拒绝。
+- Runtime `v0.2.1` Release 必须先于 Plugin package `0.5.2` 发布，并至少包含 `install.sh`、`chengfeng-videocut-portable.tar.gz` 与覆盖两者的 `SHA256SUMS.txt`。
+- `doctor` 必须显式返回 `transcriptOperations`。不能只检查 Runtime 版本：早期 `v0.2.0` Release 与同版本主分支内容不同，曾导致缺少逐词稿命令的 Release 被 Plugin 误判为兼容。
+- `v0.2.1` 必须提供正式原视频云端转录命令；缺少时以 `missing_cloud_transcription_adapter` 停止，禁止回退本地 ASR。
+- `v0.2.1` 必须内置可用 renderer；新版 Skill 不得把旧 renderer 重新打包。
 - 没有 HyperFrames 顶层 `koubo` 视图或 capability manifest 的历史 Studio 必须被能力门禁拒绝，不能再作为审核界面回退。
 - 这些缺口不允许通过旧 8898/8899 页面、直接文件写入、旧任务面板或 Skill 私有导出器绕过。
 
 ## 发布顺序
 
 ```text
-Product 0.2.0 tag
+Product 0.2.1 tag
       |
       v
 Release assets + SHA256SUMS（含 install.sh）
@@ -123,7 +124,7 @@ Release assets + SHA256SUMS（含 install.sh）
 隔离环境首次安装 + doctor + Studio capability 验收
       |
       v
-发布 Plugin package 0.5.1
+发布 Plugin package 0.5.2
 ```
 
-Plugin package 0.5.1 可以先合并代码，但在 Product Runtime v0.2.0 Release 通过验收之前不得公开发布；这段空窗期的预期行为是安全失败，而不是安装 v0.1.1。
+Plugin package 0.5.2 可以先合并代码，但在 Product Runtime v0.2.1 Release 通过验收之前不得公开发布；这段空窗期的预期行为是安全失败，而不是安装 v0.1.1。

--- a/plugins/chengfeng-videocut/runtime-requirements.json
+++ b/plugins/chengfeng-videocut/runtime-requirements.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "product": "chengfeng-videocut",
   "repository": "Agentchengfeng/chengfeng-videocut",
-  "releaseTag": "v0.2.0",
-  "releaseVersion": "0.2.0",
-  "minimumRuntimeVersion": "0.2.0",
+  "releaseTag": "v0.2.1",
+  "releaseVersion": "0.2.1",
+  "minimumRuntimeVersion": "0.2.1",
   "installerAsset": "install.sh",
   "checksumAsset": "SHA256SUMS.txt",
   "studioCapabilities": {
@@ -45,6 +45,14 @@
     ],
     "managedStudioService": true,
     "serviceParentProcessIndependent": true,
-    "serviceCrashRestart": true
+    "serviceCrashRestart": true,
+    "transcriptOperations": [
+      "playback",
+      "retranscribe",
+      "align",
+      "dictionary",
+      "regroup",
+      "correct"
+    ]
   }
 }

--- a/plugins/chengfeng-videocut/scripts/ai-term-dictionary.test.cjs
+++ b/plugins/chengfeng-videocut/scripts/ai-term-dictionary.test.cjs
@@ -1,0 +1,59 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const dictionary = fs.readFileSync(
+  path.resolve(__dirname, "..", "references", "ai-term-dictionary.md"),
+  "utf8",
+);
+const rows = dictionary
+  .split(/\r?\n/)
+  .filter((line) => /^\|[^-].*\|$/.test(line))
+  .map((line) => line.split("|").slice(1, -1).map((cell) => cell.trim()))
+  .filter(([canonical]) => canonical && canonical !== "正确写法");
+
+const aliases = new Set(
+  rows.flatMap(([, variants = ""]) =>
+    variants.split("/").map((variant) => variant.trim()).filter(Boolean)),
+);
+for (const spokenChinese of [
+  "代理",
+  "智能体",
+  "命令行",
+  "提示词",
+  "令牌",
+  "大模型",
+  "技能",
+  "工作流",
+  "叉",
+  "推特",
+  "副驾驶",
+  "光标",
+]) {
+  assert.equal(
+    aliases.has(spokenChinese),
+    false,
+    `dictionary must preserve spoken Chinese instead of translating ${spokenChinese}`,
+  );
+}
+
+const canonicalTerms = new Set(rows.map(([canonical]) => canonical));
+for (const term of [
+  "Agent",
+  "Codex",
+  "Obsidian",
+  "HyperFrames",
+  "Chengfeng",
+  "TikHub",
+  "TTS",
+  "ASR",
+]) {
+  assert.equal(canonicalTerms.has(term), true, `dictionary must include ${term}`);
+}
+
+console.log(JSON.stringify({
+  spokenChinesePreserved: true,
+  obsidianAiVocabularyIncluded: true,
+}));

--- a/plugins/chengfeng-videocut/scripts/ensure-running.test.cjs
+++ b/plugins/chengfeng-videocut/scripts/ensure-running.test.cjs
@@ -36,7 +36,7 @@ try {
   const readyBin = path.join(tmp, "ready", "chengfeng-videocut");
   writeExecutable(readyBin, `#!/bin/sh
 printf '%s\n' "$*" > "${argsFile}"
-printf '%s\n' '{"schemaVersion":1,"product":"chengfeng-videocut","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"launchd","productVersion":"0.2.0","studioBuildId":"build-123","pid":1234,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.2.0","pid":1234,"runtimeMode":"launchd","studioBuildId":"build-123"}}}'
+printf '%s\n' '{"schemaVersion":1,"product":"chengfeng-videocut","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"launchd","productVersion":"0.2.1","studioBuildId":"build-123","pid":1234,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.2.1","pid":1234,"runtimeMode":"launchd","studioBuildId":"build-123"}}}'
 `);
   const ready = run(readyBin);
   assert.equal(ready.status, 0, ready.stderr);
@@ -45,7 +45,7 @@ printf '%s\n' '{"schemaVersion":1,"product":"chengfeng-videocut","command":"serv
 
   const foregroundBin = path.join(tmp, "foreground", "chengfeng-videocut");
   writeExecutable(foregroundBin, `#!/bin/sh
-printf '%s\n' '{"schemaVersion":1,"product":"chengfeng-videocut","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"foreground","productVersion":"0.2.0","studioBuildId":"build-4321","pid":4321,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.2.0","pid":4321,"runtimeMode":"foreground","studioBuildId":"build-4321"}}}'
+printf '%s\n' '{"schemaVersion":1,"product":"chengfeng-videocut","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"foreground","productVersion":"0.2.1","studioBuildId":"build-4321","pid":4321,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.2.1","pid":4321,"runtimeMode":"foreground","studioBuildId":"build-4321"}}}'
 `);
   const foreground = run(foregroundBin);
   assert.equal(foreground.status, 21);
@@ -62,7 +62,7 @@ exit 6
 
   const forgedBin = path.join(tmp, "forged", "chengfeng-videocut");
   writeExecutable(forgedBin, `#!/bin/sh
-printf '%s\n' '{"schemaVersion":1,"product":"another-product","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"launchd","productVersion":"0.2.0","studioBuildId":"build-123","pid":1234,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.2.0","pid":1234,"runtimeMode":"launchd","studioBuildId":"build-123"}}}'
+printf '%s\n' '{"schemaVersion":1,"product":"another-product","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"launchd","productVersion":"0.2.1","studioBuildId":"build-123","pid":1234,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.2.1","pid":1234,"runtimeMode":"launchd","studioBuildId":"build-123"}}}'
 `);
   const forged = run(forgedBin);
   assert.equal(forged.status, 21);

--- a/plugins/chengfeng-videocut/scripts/ensure-runtime.cjs
+++ b/plugins/chengfeng-videocut/scripts/ensure-runtime.cjs
@@ -93,6 +93,10 @@ function loadRuntimeContract(contractPath = CONTRACT_PATH) {
     capabilities.serviceOperations.length > 0 &&
     capabilities.serviceOperations.every((operation) => typeof operation === "string") &&
     new Set(capabilities.serviceOperations).size === capabilities.serviceOperations.length &&
+    Array.isArray(capabilities.transcriptOperations) &&
+    capabilities.transcriptOperations.length > 0 &&
+    capabilities.transcriptOperations.every((operation) => typeof operation === "string") &&
+    new Set(capabilities.transcriptOperations).size === capabilities.transcriptOperations.length &&
     capabilities.managedStudioService === true &&
     capabilities.serviceParentProcessIndependent === true &&
     capabilities.serviceCrashRestart === true;
@@ -126,7 +130,10 @@ function supportsRequiredCapabilities(doctor, required = RUNTIME_CONTRACT.capabi
       capabilities.editListOperations.includes(operation)) &&
     Array.isArray(capabilities?.serviceOperations) &&
     required.serviceOperations.every((operation) =>
-      capabilities.serviceOperations.includes(operation));
+      capabilities.serviceOperations.includes(operation)) &&
+    Array.isArray(capabilities?.transcriptOperations) &&
+    required.transcriptOperations.every((operation) =>
+      capabilities.transcriptOperations.includes(operation));
 }
 
 function isExecutable(file) {

--- a/plugins/chengfeng-videocut/scripts/runtime-preflight.test.cjs
+++ b/plugins/chengfeng-videocut/scripts/runtime-preflight.test.cjs
@@ -24,6 +24,7 @@ const capabilities = {
   managedStudioService: true,
   serviceParentProcessIndependent: true,
   serviceCrashRestart: true,
+  transcriptOperations: ["playback", "retranscribe", "align", "dictionary", "regroup", "correct"],
 };
 
 function writeExecutable(file, body) {
@@ -31,7 +32,7 @@ function writeExecutable(file, body) {
   fs.writeFileSync(file, body, { mode: 0o755 });
 }
 
-function fakeRuntime(file, healthy = true, runtimeCapabilities = capabilities, version = "0.2.0") {
+function fakeRuntime(file, healthy = true, runtimeCapabilities = capabilities, version = "0.2.1") {
   writeExecutable(file, `#!/bin/sh
 if [ "$1" = "--version" ]; then echo "chengfeng-videocut ${version}"; exit 0; fi
 if [ "$1" = "doctor" ]; then echo '${JSON.stringify({ schemaVersion: 1, product: "chengfeng-videocut", command: "doctor", ok: true, data: { healthy, ...(runtimeCapabilities ? { capabilities: runtimeCapabilities } : {}) } })}'; exit 0; fi
@@ -91,6 +92,20 @@ try {
   assert.equal(incompatible.status, 14);
   assert.equal(JSON.parse(incompatible.stdout).error.code, "runtime_capability_missing");
 
+  const missingTranscriptOperationsBin = path.join(tmp, "missing-transcript-operations", "chengfeng-videocut");
+  fakeRuntime(missingTranscriptOperationsBin, true, {
+    ...capabilities,
+    transcriptOperations: undefined,
+  });
+  const missingTranscriptOperations = run(["--json"], {
+    CHENGFENG_VIDEOCUT_BIN: missingTranscriptOperationsBin,
+  });
+  assert.equal(missingTranscriptOperations.status, 14);
+  assert.equal(
+    JSON.parse(missingTranscriptOperations.stdout).error.code,
+    "runtime_capability_missing",
+  );
+
   const oldCapableBin = path.join(tmp, "old-capable", "chengfeng-videocut");
   fakeRuntime(oldCapableBin, true, capabilities, "0.1.1");
   const oldCapable = run(["--json"], { CHENGFENG_VIDEOCUT_BIN: oldCapableBin });
@@ -122,7 +137,7 @@ try {
   assert.equal(fs.existsSync(mustNotRun), false, "an existing incompatible Runtime must never be overwritten");
 
   const installHome = path.join(tmp, "installed-home");
-  const releaseDirectory = path.join(tmp, "release-v0.2.0");
+  const releaseDirectory = path.join(tmp, "release-v0.2.1");
   const observedReleaseBase = path.join(tmp, "observed-release-base");
   writeRelease(releaseDirectory, `#!/bin/sh
 set -eu
@@ -131,7 +146,7 @@ target="$CHENGFENG_VIDEOCUT_HOME/bin/chengfeng-videocut"
 mkdir -p "$(dirname "$target")"
 cat > "$target" <<'EOF'
 #!/bin/sh
-if [ "$1" = "--version" ]; then echo "chengfeng-videocut 0.2.0"; exit 0; fi
+if [ "$1" = "--version" ]; then echo "chengfeng-videocut 0.2.1"; exit 0; fi
 if [ "$1" = "doctor" ]; then echo '${JSON.stringify({ schemaVersion: 1, product: "chengfeng-videocut", command: "doctor", ok: true, data: { healthy: true, capabilities } })}'; exit 0; fi
 exit 2
 EOF
@@ -144,7 +159,7 @@ chmod +x "$target"
   });
   assert.equal(installed.status, 0, installed.stderr);
   assert.equal(JSON.parse(installed.stdout).installed, true);
-  assert.match(installed.stderr, /v0\.2\.0/);
+  assert.match(installed.stderr, /v0\.2\.1/);
   assert.equal(fs.readFileSync(observedReleaseBase, "utf8"), `file://${releaseDirectory}`);
 
   const unavailableHome = path.join(tmp, "unavailable-home");
@@ -194,6 +209,7 @@ chmod +x "$target"
     missing: 10,
     unhealthy: 11,
     incompatible: 14,
+    transcriptOperationsRequired: true,
     oldVersionRejected: true,
     foregroundOnlyRejected: true,
     incompatibleNotOverwritten: true,

--- a/plugins/chengfeng-videocut/scripts/studio-capability.test.cjs
+++ b/plugins/chengfeng-videocut/scripts/studio-capability.test.cjs
@@ -49,7 +49,7 @@ async function run() {
   assert.equal(inspectManifest({
     schemaVersion: 1,
     product: "chengfeng-videocut",
-    studioVersion: "0.2.0",
+    studioVersion: "0.2.1",
     features: {
       topLevelViews: ["storyboard", "preview", "koubo"],
       legacyWorkbenchPanel: false,
@@ -61,7 +61,7 @@ async function run() {
   const unmanaged = inspectManifest({
     schemaVersion: 1,
     product: "chengfeng-videocut",
-    studioVersion: "0.2.0",
+    studioVersion: "0.2.1",
     features: {
       topLevelViews: ["storyboard", "preview", "koubo"],
       legacyWorkbenchPanel: false,
@@ -72,7 +72,7 @@ async function run() {
   const missingOperations = inspectManifest({
     schemaVersion: 1,
     product: "chengfeng-videocut",
-    studioVersion: "0.2.0",
+    studioVersion: "0.2.1",
     features: {
       topLevelViews: ["storyboard", "preview", "koubo"],
       legacyWorkbenchPanel: false,
@@ -84,7 +84,7 @@ async function run() {
   const incompleteViews = inspectManifest({
     schemaVersion: 1,
     product: "chengfeng-videocut",
-    studioVersion: "0.2.0",
+    studioVersion: "0.2.1",
     features: {
       topLevelViews: ["koubo"],
       legacyWorkbenchPanel: false,
@@ -128,7 +128,7 @@ async function run() {
       body: JSON.stringify({
         schemaVersion: 1,
         product: "chengfeng-videocut",
-        studioVersion: "0.2.0",
+        studioVersion: "0.2.1",
         features: {
           topLevelViews: ["storyboard", "preview", "koubo"],
           legacyWorkbenchPanel: false,
@@ -141,7 +141,7 @@ async function run() {
     const result = await inspectStudio(origin, "koubo");
     assert.equal(result.ok, true);
     assert.equal(result.mode, "manifest");
-    assert.equal(result.studioVersion, "0.2.0");
+    assert.equal(result.studioVersion, "0.2.1");
     assert.equal(result.managedTimelineEditing, true);
   });
 

--- a/plugins/chengfeng-videocut/server.mjs
+++ b/plugins/chengfeng-videocut/server.mjs
@@ -84,7 +84,7 @@ const optionSchema = z.object({
   nextStep: z.string(),
 });
 
-const server = new McpServer({ name: "chengfeng-videocut", version: "0.5.1" });
+const server = new McpServer({ name: "chengfeng-videocut", version: "0.5.2" });
 
 registerAppResource(
   server,

--- a/plugins/chengfeng-videocut/skills/chengfeng-check-videocut-updates/SKILL.md
+++ b/plugins/chengfeng-videocut/skills/chengfeng-check-videocut-updates/SKILL.md
@@ -62,6 +62,6 @@ node "$UPDATE" --marketplace "$marketplaceName" --activate --confirmed \
 
 ## 边界
 
-- Plugin 可升至 `0.5.1`，不等于 Runtime 更新；Runtime 最低兼容/Release 仍由 `runtime-requirements.json` 的 `0.2.0` 合同控制。
+- Plugin 可升至 `0.5.2`，不等于 Runtime 更新；Runtime 最低兼容/Release 仍由 `runtime-requirements.json` 的 `0.2.1` 合同控制。
 - 不把本地 staging、legacy cache 或 local marketplace 说成 remotely updatable。
 - 不发布、不改 Product Runtime、5190、项目数据或媒体；用户确认后官方 Codex activation 是唯一写入例外。


### PR DESCRIPTION
## What changed

- bumps the Plugin to `0.5.2` and requires Runtime `0.2.1`
- requires explicit `transcriptOperations` in Runtime preflight
- adds a regression test that rejects a Runtime missing those operations
- removes contradictory Chinese-to-English replacements from the AI dictionary
- adds curated AI terminology found in the authorized Obsidian Creator Studio corpus
- adds a dictionary contract test that preserves spoken Chinese

## Root cause

Plugin `0.5.1` accepted the official `v0.2.0` Runtime based on a coarse capability check, while that Release did not contain transcript commands later added on Runtime `main`. The public dictionary also stated that Chinese speech must be preserved while its table encoded replacements such as `智能体 -> Agent` and `技能 -> Skill`.

## Impact

The Plugin now rejects incompatible Runtime packages before a workflow starts. Proper-noun correction keeps the speaker's actual Chinese wording and covers the author's recurring AI vocabulary without inventing unsupported phonetic aliases.

## Validation

- Plugin build passed
- full Plugin test suite passed
- real project Runtime preflight passed against locally packaged `0.2.1`
- real `transcript playback`, `align`, and dictionary dry-run commands passed
