### PR TITLE
候选：Plugin 0.10.8 绑定 Runtime v0.4.8 portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Runtime 默认安装到：
 ~/.chengfeng-videocut
 ```
 
-Plugin 0.10.7 的产品合同固定为 `v0.4.7` Release、Runtime 0.4.7+ EDL 与跨平台用户级常驻 service 能力，以及 Studio 的三个顶层视图与 `managedTimelineEditing=true`。桌面路径优先识别受管安装；纯 CLI 首次安装会从这个精确 Release 下载 `install.cjs` 和 `SHA256SUMS.txt`，先验证安装器，再让安装器读取同一个 Release 的产品包；不使用会漂移的 `latest`。Release 不存在、资产不全、哈希不匹配或已有 Runtime 不兼容时均停止，不覆盖现有安装，也不回退旧版。
+Plugin 0.10.8 的产品合同固定为 `v0.4.8` Release、Runtime 0.4.8+ EDL 与跨平台用户级常驻 service 能力，以及 Studio 的三个顶层视图与 `managedTimelineEditing=true`。桌面路径优先识别受管安装；纯 CLI 首次安装只从这个精确 Release 下载 `install.cjs`、`SHA256SUMS.txt` 与 Runtime portable contract；安装器只消费 `chengfeng-videocut-portable.tar.gz`，并要求清单同时覆盖它和版本化的 `chengfeng-videocut-0.4.8-portable.tar.gz`，绝不下载桌面 DMG/EXE。不使用会漂移的 `latest`。Release 不存在、portable 资产或哈希不全、哈希不匹配或已有 Runtime 不兼容时均停止，不覆盖现有安装，也不回退旧版。
 
 每个业务流程在第一次产品 API 前、每次人工审核恢复前都会执行共享 `ensure-running`：
 
@@ -220,11 +220,12 @@ chengfeng-videocut-skills/
 
 ## 发布边界
 
-Plugin 0.10.7 依赖 Runtime 0.4.7 的 Windows 安装、用户服务与当前 EDL / Studio 合同。稳定发布顺序是：
+Plugin 0.10.8 依赖 Runtime 0.4.8 的 portable 安装、用户服务与当前 EDL / Studio 合同。稳定发布顺序是：
 
 ```text
-Runtime v0.4.7 Release
-  -> install.sh、install.cjs 与全部产品包进入 SHA256SUMS
+Runtime v0.4.8 Release
+  -> install.sh、install.cjs、版本化/稳定名 portable 与 tgz 进入 SHA256SUMS
+  -> Skills 路径只下载 stable portable tarball，不下载 Desktop DMG/EXE
   -> 从公开附件在 Windows / macOS 隔离环境安装并执行 doctor
   -> Plugin 内容提交 A
   -> 只增加 provenance 的 Marketplace 快照 B

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ winget install Oven-sh.Bun OpenJS.NodeJS.LTS Gyan.FFmpeg Google.Chrome
 Skill 合同的行为（真实发生过：Runtime 缺失时 Agent 手搓了一个"审片台"，产出与产品
 完全不兼容）。遇到这种情况，把 Agent 的报错原文发 Issue。
 
-当前 `main` 候选 Plugin 是 `0.10.7`。内容提交 A 为
-`59f42c0901cbc85834a1617dc4a8c0e354f16298`，带 provenance 的 Marketplace
-快照 B 为 `5d299dc0eb07f02f085cbf6a63bf09b42638ed5e`；Bootstrap manifest 固定
+本次待发布 Plugin 是 `0.10.8`。内容提交 A 为
+`a513462f65b6f50083a20ac8da6ec3c32d2ddcde`，带 provenance 的 Marketplace
+快照 B 为 `1487e02b1c0c39ea74d079e8ce45da56bf59bc32`；Bootstrap manifest 永久固定
 到 B。候选验证环境可使用 Codex Marketplace 安装：
 
 ```bash
-codex plugin marketplace add Agentchengfeng/chengfeng-videocut-skills --ref 5d299dc0eb07f02f085cbf6a63bf09b42638ed5e && codex plugin marketplace upgrade chengfeng-videocut --json && codex plugin add chengfeng-videocut@chengfeng-videocut
+codex plugin marketplace add Agentchengfeng/chengfeng-videocut-skills --ref 1487e02b1c0c39ea74d079e8ce45da56bf59bc32 && codex plugin marketplace upgrade chengfeng-videocut --json && codex plugin add chengfeng-videocut@chengfeng-videocut
 ```
 
 三段必须分开是 Codex 官方 CLI 的机制：`marketplace add --ref <SHA>` 先挂市场，
@@ -71,8 +71,11 @@ codex plugin marketplace add Agentchengfeng/chengfeng-videocut-skills --ref 5d29
 
 Bootstrap 仍只调用官方 `plugin marketplace add --ref <40hex>`、`plugin marketplace upgrade` 与 `plugin add`，随后做只读回查；Marketplace upgrade 只 materialize manifest 固定的精确插件快照，不安装、升级、启动或修改 Product Runtime。由于 Codex 0.146 会在 Marketplace 缺失时从 `plugin list` 隐藏同市场孤儿插件，Bootstrap 会紧接 `marketplace add`、在 `marketplace upgrade` 之前执行 `plugin list --marketplace <name> --available --json`；只有目标条目明确为 `installed=false`、`enabled=false` 才继续。若此时发现已安装或已启用的既有插件，只撤回本次新增的 Marketplace，明确保留孤儿插件状态并拒绝继续，避免 upgrade 先覆盖其 cache。其他失败若发生在插件激活已经开始之后，则先执行官方 `plugin remove`，再移除本次 `alreadyAdded=false` 的目标市场，并通过 `marketplace list` 与 `plugin list` 双重回查确认本次新增状态已消失；它不碰安装前已存在的 Marketplace 或插件，主错误与回滚结果会同时报告。Bootstrap 不复制 Skill 文件。manifest 固定不可变快照 B，B 内的 provenance 再绑定内容提交 A 与完整 bundle 摘要。npm 的 GitHub git-spec 在已验证环境中不能稳定启动，因此不把 `npx github:...` 作为对外稳定安装承诺。
 
-上面的三段命令只用于候选验证和干净安装；`stable` 在公开 Runtime 与双平台验证通过前
-保持原版本。已经安装 0.10.5 / 0.10.6 的测试用户应让 Codex 执行“检查更新”，
+发布完成后的远端分层为：`stable` 指向 B，仅供更新检查在隔离 `CODEX_HOME` 中发现
+候选；用户 Marketplace 和 Bootstrap 都必须固定 B，不能跟踪 `stable`。`main` 指向只改
+根 Bootstrap manifest 与 README 的提交 C，Plugin 子树与 B 完全相同。公开 Runtime
+与双平台验收完成前，不得移动 `stable` 或把本候选表述为可下载版本。已经安装 0.10.5 /
+0.10.6 的测试用户应让 Codex 执行“检查更新”，
 核对 version + B + A + SHA-256 后确认激活，并在成功后新开任务；若 Windows 报 cache
 被占用，先完整退出旧 Codex Desktop/任务再重试，不要手工删除 cache。
 
@@ -229,7 +232,8 @@ Runtime v0.4.8 Release
   -> 从公开附件在 Windows / macOS 隔离环境安装并执行 doctor
   -> Plugin 内容提交 A
   -> 只增加 provenance 的 Marketplace 快照 B
-  -> stable 指向 B，Bootstrap manifest 固定 B
+  -> 根 Bootstrap 提交 C（只改 manifest / README，Plugin 子树仍等于 B）
+  -> stable 指向 B，main 指向 C，Bootstrap manifest 固定 B
   -> 从公开入口验证干净安装与 0.10.5 更新
 ```
 

--- a/installer-manifest.json
+++ b/installer-manifest.json
@@ -4,8 +4,8 @@
   "source": "Agentchengfeng/chengfeng-videocut-skills",
   "marketplace": "chengfeng-videocut",
   "plugin": "chengfeng-videocut",
-  "marketplaceRef": "5d299dc0eb07f02f085cbf6a63bf09b42638ed5e",
-  "pluginRef": "5d299dc0eb07f02f085cbf6a63bf09b42638ed5e",
+  "marketplaceRef": "1487e02b1c0c39ea74d079e8ce45da56bf59bc32",
+  "pluginRef": "1487e02b1c0c39ea74d079e8ce45da56bf59bc32",
   "runtimeInstall": false,
   "allowedCommands": [
     "codex plugin marketplace add",

--- a/plugins/chengfeng-videocut/.codex-plugin/plugin.json
+++ b/plugins/chengfeng-videocut/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chengfeng-videocut",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Six task-facing chengfeng-videocut Skills: cut, subtitle, visual, export, safe bug reporting, and Marketplace update checks. Shared product boundaries are internal references, not a user-facing Skill.",
   "author": {
     "name": "Chengfeng",

--- a/plugins/chengfeng-videocut/.codex-plugin/update-provenance.json
+++ b/plugins/chengfeng-videocut/.codex-plugin/update-provenance.json
@@ -1,6 +1,6 @@
 {
   "name": "chengfeng-videocut",
-  "version": "0.10.7",
-  "immutableRef": "59f42c0901cbc85834a1617dc4a8c0e354f16298",
-  "publisherChecksum": "fa03d196fc072790efaaa75e950ff53f5defa09c9809e07b98289f7f311f5488"
+  "version": "0.10.8",
+  "immutableRef": "a513462f65b6f50083a20ac8da6ec3c32d2ddcde",
+  "publisherChecksum": "406a79069dfff13e0d82095ed8c560ee863d670497ffa71313e1e7ae63f73c71"
 }

--- a/plugins/chengfeng-videocut/README.md
+++ b/plugins/chengfeng-videocut/README.md
@@ -40,7 +40,7 @@ $chengfeng-videocut:chengfeng-check-updates
 
 共同边界只存在于 `references/runtime-and-product-contract.md` 与 `references/business-workflow-contract.md`。普通 reference 没有 `SKILL.md`、公开 ID 或 UI 卡片，不占用用户入口。
 
-业务 Skill 共用 `scripts/ensure-runtime.cjs`、`scripts/ensure-running.cjs` 和 `runtime-requirements.json`。Plugin package `0.10.7` 消费 Runtime compatibility contract `0.4.7`：只接受 Runtime 0.4.7+ 与声明的 EDL、常驻 service 能力；缺失时从精确的 `v0.4.7` Release 获取 `install.cjs` 和校验清单，校验后安装并执行 doctor。已有低版本 Runtime 只有在用户明确确认升级时才原子替换程序目录，项目数据不动。随后由 Product `service ensure --json` 幂等安装或恢复 macOS launchd / Windows Task Scheduler 用户服务；Plugin 不直接使用操作系统进程管理命令或 foreground 后台进程。Release 不存在、资产不完整或服务身份不匹配时安全停止。Studio 只在人工审核状态且通过 `ensure-studio.cjs` 顶层视图能力门禁后打开。
+业务 Skill 共用 `scripts/ensure-runtime.cjs`、`scripts/ensure-running.cjs` 和 `runtime-requirements.json`。Plugin package `0.10.8` 消费 Runtime compatibility contract `0.4.8`：只接受 Runtime 0.4.8+ 与声明的 EDL、常驻 service 能力；缺失时从精确的 `v0.4.8` Release 获取 `install.cjs` 和校验清单。安装器只消费 stable Runtime portable `chengfeng-videocut-portable.tar.gz`；清单必须同时声明该资产和版本化 `chengfeng-videocut-0.4.8-portable.tar.gz`，不下载 Desktop DMG/EXE。校验后安装并执行 doctor。已有低版本 Runtime 只有在用户明确确认升级时才原子替换程序目录，项目数据不动。随后由 Product `service ensure --json` 幂等安装或恢复 macOS launchd / Windows Task Scheduler 用户服务；Plugin 不直接使用操作系统进程管理命令或 foreground 后台进程。Release 不存在、资产不完整或服务身份不匹配时安全停止。Studio 只在人工审核状态且通过 `ensure-studio.cjs` 顶层视图能力门禁后打开。
 
 桌面 App 与纯 CLI 不是两套 Runtime。App 首次启动把随包 Runtime、Bun、FFmpeg 和
 FFprobe 安装到 `~/.chengfeng-videocut` 的版本化目录，并由同一个稳定 launcher
@@ -97,7 +97,7 @@ Marketplace/Plugin 后，先以 manifest 的 exact 40-hex ref 执行 Marketplace
 Plugin add；后续失败则按本次实际创建的状态执行 Plugin remove → Marketplace
 remove，并再次复读确认。
 
-Plugin 是独立的 `0.10.7` 版本；`runtime-requirements.json` 要求 Product Runtime `0.4.7`。两者不能互相替代。
+Plugin 是独立的 `0.10.8` 版本；`runtime-requirements.json` 要求 Product Runtime `0.4.8`。两者不能互相替代。
 
 ## 开发验证
 

--- a/plugins/chengfeng-videocut/dist/server.mjs
+++ b/plugins/chengfeng-videocut/dist/server.mjs
@@ -6733,7 +6733,7 @@ var review_confirm_default = `<!doctype html>
 // package.json
 var package_default = {
   name: "chengfeng-videocut-codex-plugin",
-  version: "0.10.7",
+  version: "0.10.8",
   private: true,
   type: "module",
   scripts: {

--- a/plugins/chengfeng-videocut/package-lock.json
+++ b/plugins/chengfeng-videocut/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chengfeng-videocut-codex-plugin",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chengfeng-videocut-codex-plugin",
-      "version": "0.10.7",
+      "version": "0.10.8",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "1.0.1",
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/plugins/chengfeng-videocut/package.json
+++ b/plugins/chengfeng-videocut/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chengfeng-videocut-codex-plugin",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/chengfeng-videocut/references/runtime-and-product-contract.md
+++ b/plugins/chengfeng-videocut/references/runtime-and-product-contract.md
@@ -27,15 +27,15 @@ ensure-runtime
                                       停止，不回退旧剪辑链
 ```
 
-- Plugin package `0.10.7` 消费的机器可读 Runtime compatibility contract 是 `runtime-requirements.json`：`releaseTag=v0.4.7`、`releaseVersion=0.4.7`、最低 Runtime 为 `0.4.7`，并声明 Runtime EDL、Studio 与跨平台用户服务能力集合。
-- 缺失时只从 `v0.4.7` 的精确 Release 下载 `install.cjs` 与 `SHA256SUMS.txt`；先校验安装器本身，再执行安装器。安装器收到同一个精确 Release 地址，不得访问 `latest`。
+- Plugin package `0.10.8` 消费的机器可读 Runtime compatibility contract 是 `runtime-requirements.json`：`releaseTag=v0.4.8`、`releaseVersion=0.4.8`、最低 Runtime 为 `0.4.8`，并声明 Runtime EDL、Studio 与跨平台用户服务能力集合。
+- 缺失时只从 `v0.4.8` 的精确 Release 下载 `install.cjs` 与 `SHA256SUMS.txt`；先校验安装器本身，并要求清单包含 stable `chengfeng-videocut-portable.tar.gz` 与版本化 `chengfeng-videocut-0.4.8-portable.tar.gz`。安装器只消费 stable portable tarball，不得下载 Desktop DMG/EXE；它收到同一个精确 Release 地址，不得访问 `latest`。
 - 桌面安装是另一条受支持的 Product 分发入口：App 首启把随包 Runtime、Bun、
   FFmpeg、FFprobe 写入相同受管根并执行同一个 `service ensure`。成功后只读探测
   返回 `kind=desktop-managed`；业务合同、CLI/API 和服务身份不变。
-- `v0.4.7` Release 尚不存在、缺少安装器、缺少安装器校验值或哈希不符时，以 `install_failed` 停止；纯 CLI 路径不得转装公开旧版、源码 clone、npm 或 bunx。
+- `v0.4.8` Release 尚不存在、缺少安装器、portable 资产校验值或哈希不符时，以 `install_failed` 停止；纯 CLI 路径不得转装公开旧版、源码 clone、npm、bunx、DMG 或 EXE。
 - 安装位置是 `CHENGFENG_VIDEOCUT_HOME` 或 `~/.chengfeng-videocut`。
-- CLI 已存在但 doctor 失败时不自动覆盖或循环重装；已有 Runtime 低于 0.4.7 时也不静默覆盖，只有用户明确确认 `--upgrade` 才原子替换程序目录。
-- CLI doctor 健康但版本低于 0.4.7，或缺少 EDL schema、expected revision、managed A-roll projection、move / trim / split / delete、service API、父进程独立存活或 crash restart capability 时，以 `runtime_capability_missing` 停止；不把“健康”误当“兼容”。
+- CLI 已存在但 doctor 失败时不自动覆盖或循环重装；已有 Runtime 低于 0.4.8 时也不静默覆盖，只有用户明确确认 `--upgrade` 才原子替换程序目录。
+- CLI doctor 健康但版本低于 0.4.8，或缺少 EDL schema、expected revision、managed A-roll projection、move / trim / split / delete、service API、父进程独立存活或 crash restart capability 时，以 `runtime_capability_missing` 停止；不把“健康”误当“兼容”。
 - 查找顺序：显式 `CHENGFENG_VIDEOCUT_BIN`、托管安装目录、PATH、显式开发目录
   `CHENGFENG_VIDEOCUT_DIR`。这确保桌面版稳定入口不会被 PATH 中的旧 CLI 遮蔽。
 - Plugin 不搜索 Electron `.app`、NSIS 目录或 resources；只有桌面 App 自己能把
@@ -56,7 +56,7 @@ Product service ensure --json
 ```
 
 - Plugin 不直接调用 `launchctl`、`nohup`、PID 文件或后台进程 API；服务安装、启动、升级收敛和 crash restart 全部属于 Product。
-- `service ensure` 成功必须返回 `ok=true`，且 `data` 同时满足：`healthy=true`、`runtimeMode=launchd|windows-task`、`productVersion>=0.4.7`、正整数 `pid`、`url=http://127.0.0.1:5190/`。
+- `service ensure` 成功必须返回 `ok=true`，且 `data` 同时满足：`healthy=true`、`runtimeMode=launchd|windows-task`、`productVersion>=0.4.8`、正整数 `pid`、`url=http://127.0.0.1:5190/`。
 - 健康服务会幂等复用；页面或 Codex 父终端关闭不应结束服务。
 - 返回 foreground 身份、未知端口占用、错误 URL、旧版本或不完整 JSON 时 fail-closed；Skill 不杀进程、不换 5191、不回退临时 foreground。
 - `service ensure` 不创建项目、不打开 Studio；仍只在 `*_review_ready` 后执行 `open`。
@@ -110,10 +110,10 @@ Product open 返回项目 URL
 
 ## 当前 Runtime 兼容门禁
 
-- 低于 0.4.7 的 Runtime 不具备本 Plugin 发布所绑定的完整 Windows 安装修复与当前 EDL / Studio compatibility contract，必须被版本门禁拒绝，直到用户明确确认升级。
-- Runtime `v0.4.7` Release 必须先于 Plugin package `0.10.7` 发布，并至少包含 `install.cjs`、版本化/稳定名 portable 与 tgz、覆盖所有正式附件的 `SHA256SUMS.txt`。
-- `v0.4.7` 必须提供正式原视频云端转录命令；缺少时以 `missing_cloud_transcription_adapter` 停止，禁止回退本地 ASR。
-- `v0.4.7` 必须内置可用 renderer；新版 Skill 不得把旧 renderer 重新打包。
+- 低于 0.4.8 的 Runtime 不具备本 Plugin 发布所绑定的完整更新事务与当前 EDL / Studio compatibility contract，必须被版本门禁拒绝，直到用户明确确认升级。
+- Runtime `v0.4.8` Release 必须先于 Plugin package `0.10.8` 发布，并至少包含 `install.cjs`、stable `chengfeng-videocut-portable.tar.gz`、版本化 `chengfeng-videocut-0.4.8-portable.tar.gz`、版本化/稳定名 tgz，以及覆盖这些资产和安装器的 `SHA256SUMS.txt`；桌面 DMG/EXE 不是 Skills 安装输入。
+- `v0.4.8` 必须提供正式原视频云端转录命令；缺少时以 `missing_cloud_transcription_adapter` 停止，禁止回退本地 ASR。
+- `v0.4.8` 必须内置可用 renderer；新版 Skill 不得把旧 renderer 重新打包。
 - 没有 HyperFrames 顶层 `koubo` 视图或 capability manifest 的历史 Studio 必须被能力门禁拒绝，不能再作为审核界面回退。
 - 这些缺口不允许通过旧 8898/8899 页面、直接文件写入、旧任务面板或 Skill 私有导出器绕过。
 
@@ -256,7 +256,7 @@ plugin add
 ## 发布顺序
 
 ```text
-Product 0.4.7 tag
+Product 0.4.8 tag
       |
       v
 Release assets + SHA256SUMS（含 install.cjs）
@@ -265,7 +265,7 @@ Release assets + SHA256SUMS（含 install.cjs）
 隔离环境首次安装 + doctor + Studio capability 验收
       |
       v
-Plugin 0.10.7 内容提交
+Plugin 0.10.8 内容提交
       |
       +------------------------------> contentRevision A
       |
@@ -281,4 +281,4 @@ Plugin 0.10.7 内容提交
 用户确认后固定安装 --ref B
 ```
 
-Plugin package 0.10.7 可以先形成候选，但在 Product Runtime v0.4.7 Release 与双平台桌面包通过公开下载、安装和 Skills 共用服务验收之前不得推进 `stable`；这段空窗期的预期行为是安全失败，而不是安装旧 Runtime。
+Plugin package 0.10.8 可以先形成候选，但在 Product Runtime v0.4.8 Release 的 portable 资产通过公开下载、安装和 Skills 共用服务验收之前不得推进 `stable`；这段空窗期的预期行为是安全失败，而不是安装旧 Runtime 或桌面安装包。

--- a/plugins/chengfeng-videocut/runtime-requirements.json
+++ b/plugins/chengfeng-videocut/runtime-requirements.json
@@ -2,10 +2,12 @@
   "schemaVersion": 1,
   "product": "chengfeng-videocut",
   "repository": "Agentchengfeng/chengfeng-videocut",
-  "releaseTag": "v0.4.7",
-  "releaseVersion": "0.4.7",
-  "minimumRuntimeVersion": "0.4.7",
+  "releaseTag": "v0.4.8",
+  "releaseVersion": "0.4.8",
+  "minimumRuntimeVersion": "0.4.8",
   "installerAsset": "install.cjs",
+  "portableAsset": "chengfeng-videocut-portable.tar.gz",
+  "versionedPortableAsset": "chengfeng-videocut-0.4.8-portable.tar.gz",
   "checksumAsset": "SHA256SUMS.txt",
   "studioCapabilities": {
     "topLevelViews": [

--- a/plugins/chengfeng-videocut/scripts/ensure-running.test.cjs
+++ b/plugins/chengfeng-videocut/scripts/ensure-running.test.cjs
@@ -8,6 +8,7 @@ const { spawnSync } = require("node:child_process");
 
 const root = path.resolve(__dirname, "..");
 const ensureRunning = path.join(root, "scripts", "ensure-running.cjs");
+const runtimeContract = JSON.parse(fs.readFileSync(path.join(root, "runtime-requirements.json"), "utf8"));
 const cutSkill = fs.readFileSync(path.join(root, "skills", "chengfeng-cut", "SKILL.md"), "utf8");
 const exportSkill = fs.readFileSync(path.join(root, "skills", "chengfeng-export", "SKILL.md"), "utf8");
 const subtitleSkill = fs.readFileSync(path.join(root, "skills", "chengfeng-subtitle", "SKILL.md"), "utf8");
@@ -64,7 +65,7 @@ try {
   const argsFile = path.join(tmp, "args.txt");
   const readyBin = fakeRuntime(
     path.join(tmp, "ready", "chengfeng-videocut"),
-    `{"schemaVersion":1,"product":"chengfeng-videocut","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"${expectedRuntimeMode}","productVersion":"0.4.7","studioBuildId":"build-123","pid":1234,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.4.7","pid":1234,"runtimeMode":"${expectedRuntimeMode}","studioBuildId":"build-123"}}}`,
+    `{"schemaVersion":1,"product":"chengfeng-videocut","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"${expectedRuntimeMode}","productVersion":"${runtimeContract.minimumRuntimeVersion}","studioBuildId":"build-123","pid":1234,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"${runtimeContract.minimumRuntimeVersion}","pid":1234,"runtimeMode":"${expectedRuntimeMode}","studioBuildId":"build-123"}}}`,
     0,
     argsFile,
   );
@@ -75,7 +76,7 @@ try {
 
   const foregroundBin = fakeRuntime(
     path.join(tmp, "foreground", "chengfeng-videocut"),
-    '{"schemaVersion":1,"product":"chengfeng-videocut","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"foreground","productVersion":"0.4.7","studioBuildId":"build-4321","pid":4321,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.4.7","pid":4321,"runtimeMode":"foreground","studioBuildId":"build-4321"}}}',
+    `{"schemaVersion":1,"product":"chengfeng-videocut","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"foreground","productVersion":"${runtimeContract.minimumRuntimeVersion}","studioBuildId":"build-4321","pid":4321,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"${runtimeContract.minimumRuntimeVersion}","pid":4321,"runtimeMode":"foreground","studioBuildId":"build-4321"}}}`,
   );
   const foreground = run(foregroundBin);
   assert.equal(foreground.status, 21);
@@ -92,7 +93,7 @@ try {
 
   const forgedBin = fakeRuntime(
     path.join(tmp, "forged", "chengfeng-videocut"),
-    `{"schemaVersion":1,"product":"another-product","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"${expectedRuntimeMode}","productVersion":"0.4.7","studioBuildId":"build-123","pid":1234,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"0.4.7","pid":1234,"runtimeMode":"${expectedRuntimeMode}","studioBuildId":"build-123"}}}`,
+    `{"schemaVersion":1,"product":"another-product","command":"service.ensure","ok":true,"data":{"serviceApiVersion":1,"action":"ensure","state":"running","ready":true,"healthy":true,"configured":true,"runtimeMode":"${expectedRuntimeMode}","productVersion":"${runtimeContract.minimumRuntimeVersion}","studioBuildId":"build-123","pid":1234,"url":"http://127.0.0.1:5190/","identity":{"product":"chengfeng-videocut","productVersion":"${runtimeContract.minimumRuntimeVersion}","pid":1234,"runtimeMode":"${expectedRuntimeMode}","studioBuildId":"build-123"}}}`,
   );
   const forged = run(forgedBin);
   assert.equal(forged.status, 21);

--- a/plugins/chengfeng-videocut/scripts/ensure-runtime.cjs
+++ b/plugins/chengfeng-videocut/scripts/ensure-runtime.cjs
@@ -76,6 +76,9 @@ function loadRuntimeContract(contractPath = CONTRACT_PATH) {
     contract.releaseTag === `v${contract.releaseVersion}` &&
     parseSemver(contract?.minimumRuntimeVersion) !== null &&
     /^[A-Za-z0-9_.-]+$/.test(contract?.installerAsset || "") &&
+    contract?.portableAsset === "chengfeng-videocut-portable.tar.gz" &&
+    contract?.versionedPortableAsset ===
+      `chengfeng-videocut-${contract.releaseVersion}-portable.tar.gz` &&
     /^[A-Za-z0-9_.-]+$/.test(contract?.checksumAsset || "") &&
     isPlainObject(studioCapabilities) &&
     Array.isArray(studioCapabilities.topLevelViews) &&
@@ -316,7 +319,8 @@ function expectedChecksum(checksumText, assetName) {
 }
 
 function verifyInstaller(installer, checksumFile) {
-  const expected = expectedChecksum(readFileSync(checksumFile, "utf8"), RUNTIME_CONTRACT.installerAsset);
+  const sums = readFileSync(checksumFile, "utf8");
+  const expected = expectedChecksum(sums, RUNTIME_CONTRACT.installerAsset);
   if (!expected) {
     throw new RuntimeInstallError(
       "runtime_release_incomplete",
@@ -329,6 +333,14 @@ function verifyInstaller(installer, checksumFile) {
       "installer_checksum_mismatch",
       `${RUNTIME_CONTRACT.releaseTag} 安装器 SHA-256 校验失败；安装已停止。`,
     );
+  }
+  for (const asset of [RUNTIME_CONTRACT.portableAsset, RUNTIME_CONTRACT.versionedPortableAsset]) {
+    if (!expectedChecksum(sums, asset)) {
+      throw new RuntimeInstallError(
+        "runtime_release_incomplete",
+        `${RUNTIME_CONTRACT.releaseTag} 的 ${RUNTIME_CONTRACT.checksumAsset} 未声明 Runtime portable asset ${asset}；安装已停止。`,
+      );
+    }
   }
 }
 

--- a/plugins/chengfeng-videocut/scripts/runtime-preflight.test.cjs
+++ b/plugins/chengfeng-videocut/scripts/runtime-preflight.test.cjs
@@ -46,7 +46,7 @@ function writeNodeExecutable(file, body) {
   return file;
 }
 
-function fakeRuntime(file, healthy = true, runtimeCapabilities = capabilities, version = "0.4.7") {
+function fakeRuntime(file, healthy = true, runtimeCapabilities = capabilities, version = "0.4.8") {
   const doctor = JSON.stringify({
     schemaVersion: 1,
     product: "chengfeng-videocut",
@@ -71,15 +71,19 @@ process.exit(2);
 `);
 }
 
-function writeRelease(directory, installerBody, checksum = true) {
+function writeRelease(directory, installerBody, checksum = true, portableChecksums = true) {
   fs.mkdirSync(directory, { recursive: true });
   const installer = path.join(directory, "install.cjs");
   writeExecutable(installer, installerBody);
   const actual = createHash("sha256").update(fs.readFileSync(installer)).digest("hex");
-  fs.writeFileSync(
-    path.join(directory, "SHA256SUMS.txt"),
-    `${checksum === true ? actual : String(checksum)}  install.cjs\n`,
-  );
+  const lines = [`${checksum === true ? actual : String(checksum)}  install.cjs`];
+  if (portableChecksums) {
+    lines.push(
+      `${"1".repeat(64)}  ${runtimeContract.portableAsset}`,
+      `${"2".repeat(64)}  ${runtimeContract.versionedPortableAsset}`,
+    );
+  }
+  fs.writeFileSync(path.join(directory, "SHA256SUMS.txt"), `${lines.join("\n")}\n`);
   return installer;
 }
 
@@ -100,6 +104,13 @@ try {
   assert.equal(runtimeContract.releaseTag, `v${runtimeContract.releaseVersion}`);
   assert.notEqual(pluginManifest.version, runtimeContract.releaseVersion, "Plugin package version is independent from Product Runtime release version");
   assert.equal(runtimeContract.minimumRuntimeVersion, runtimeContract.releaseVersion, "the independent Plugin still declares its minimum compatible Runtime");
+  assert.equal(runtimeContract.portableAsset, "chengfeng-videocut-portable.tar.gz");
+  assert.equal(
+    runtimeContract.versionedPortableAsset,
+    `chengfeng-videocut-${runtimeContract.releaseVersion}-portable.tar.gz`,
+  );
+  assert.doesNotMatch(runtimeContract.portableAsset, /\.(dmg|exe)$/i);
+  assert.doesNotMatch(runtimeContract.versionedPortableAsset, /\.(dmg|exe)$/i);
 
   const readyBin = fakeRuntime(path.join(tmp, "ready", "chengfeng-videocut"), true);
   const ready = run(["--json"], { CHENGFENG_VIDEOCUT_BIN: readyBin });
@@ -112,14 +123,14 @@ try {
     true,
   );
   fs.mkdirSync(path.join(desktopHome, "app", "current"), { recursive: true });
-  fs.writeFileSync(path.join(desktopHome, "app", "current", "VERSION"), "0.4.7\n");
+  fs.writeFileSync(path.join(desktopHome, "app", "current", "VERSION"), "0.4.8\n");
   fs.writeFileSync(
     path.join(desktopHome, "desktop-installation.json"),
     JSON.stringify({
       schemaVersion: 1,
       product: "chengfeng-videocut",
       source: "desktop",
-      productVersion: "0.4.7",
+      productVersion: "0.4.8",
     }),
   );
   const pathRuntimeDir = path.join(tmp, "path-runtime");
@@ -133,7 +144,7 @@ try {
   const desktopPayload = JSON.parse(desktopManaged.stdout);
   assert.equal(desktopPayload.runtime.kind, "desktop-managed");
   assert.equal(desktopPayload.runtime.command, desktopBin);
-  assert.equal(desktopPayload.runtime.runtimeVersion, "0.4.7");
+  assert.equal(desktopPayload.runtime.runtimeVersion, "0.4.8");
 
   const missing = run(["--json"], { CHENGFENG_VIDEOCUT_BIN: path.join(tmp, "missing") });
   assert.equal(missing.status, 10);
@@ -183,14 +194,14 @@ try {
   assert.equal(fs.existsSync(mustNotRun), false, "an existing incompatible Runtime must never be overwritten");
 
   const installHome = path.join(tmp, "installed-home");
-  const releaseDirectory = path.join(tmp, "release-v0.4.7");
+  const releaseDirectory = path.join(tmp, "release-v0.4.8");
   const observedReleaseBase = path.join(tmp, "observed-release-base");
   const releaseRuntimeDirectory = path.join(tmp, "release-runtime");
   fakeRuntime(
     path.join(releaseRuntimeDirectory, "chengfeng-videocut"),
     true,
     capabilities,
-    "0.4.7",
+    "0.4.8",
   );
   writeRelease(releaseDirectory, `
 const nodeFs = require("node:fs");
@@ -206,7 +217,7 @@ nodeFs.cpSync(${JSON.stringify(releaseRuntimeDirectory)}, target, { recursive: t
   });
   assert.equal(installed.status, 0, installed.stderr);
   assert.equal(JSON.parse(installed.stdout).installed, true);
-  assert.match(installed.stderr, /v0\.4\.7/);
+  assert.match(installed.stderr, /v0\.4\.8/);
   assert.equal(fs.readFileSync(observedReleaseBase, "utf8"), `file://${releaseDirectory}`);
 
   const unavailableHome = path.join(tmp, "unavailable-home");
@@ -240,6 +251,23 @@ nodeFs.cpSync(${JSON.stringify(releaseRuntimeDirectory)}, target, { recursive: t
   assert.equal(badChecksum.status, 12);
   assert.equal(JSON.parse(badChecksum.stdout).error.details.reasonCode, "installer_checksum_mismatch");
   assert.equal(fs.existsSync(checksumMarker), false, "an unverified installer must never execute");
+
+  const incompletePortableRelease = path.join(tmp, "release-missing-portable-checksum");
+  const incompletePortableMarker = path.join(tmp, "portable-checksum-installer-ran");
+  writeRelease(
+    incompletePortableRelease,
+    `require("node:fs").writeFileSync(${JSON.stringify(incompletePortableMarker)}, "");\n`,
+    true,
+    false,
+  );
+  const incompletePortable = run(["--install-if-missing", "--json"], {
+    CHENGFENG_VIDEOCUT_BIN: path.join(tmp, "missing-portable-checksum-bin"),
+    CHENGFENG_VIDEOCUT_HOME: path.join(tmp, "incomplete-portable-home"),
+    CHENGFENG_VIDEOCUT_RELEASE_BASE: `file://${incompletePortableRelease}`,
+  });
+  assert.equal(incompletePortable.status, 12);
+  assert.equal(JSON.parse(incompletePortable.stdout).error.details.reasonCode, "runtime_release_incomplete");
+  assert.equal(fs.existsSync(incompletePortableMarker), false, "a release without portable SHA-256 entries must not execute its installer");
 
   // 用户确认后的原子升级：托管位置有旧版（能力齐但版本旧）→ --upgrade 放行安装器。
   const upgradeHome = path.join(tmp, "upgrade-home");
@@ -283,6 +311,7 @@ nodeFs.cpSync(${JSON.stringify(releaseRuntimeDirectory)}, target, { recursive: t
     installedFromExactRelease: true,
     unavailableReleaseFailedClosed: true,
     badChecksumFailedClosed: true,
+    portableChecksumRequiredBeforeInstallerRuns: true,
     installFailed: 12,
   }));
 } finally {

--- a/test/bootstrap.test.cjs
+++ b/test/bootstrap.test.cjs
@@ -10,6 +10,9 @@ const test = require('node:test');
 const ROOT = path.resolve(__dirname, '..');
 const SOURCE = 'Agentchengfeng/chengfeng-videocut-skills';
 const ORIGIN = `https://github.com/${SOURCE}.git`;
+const RELEASE_PLUGIN_VERSION = '0.10.8';
+const RELEASE_CONTENT_REF = 'a513462f65b6f50083a20ac8da6ec3c32d2ddcde';
+const RELEASE_SNAPSHOT_REF = '1487e02b1c0c39ea74d079e8ce45da56bf59bc32';
 
 function run(command, args, options = {}) {
   const batch = process.platform === 'win32' && /^(npm|npx|pnpm|yarn)$/i.test(command)
@@ -28,6 +31,46 @@ function run(command, args, options = {}) {
   assert.equal(result.status, 0, `${command} ${args.join(' ')}\n${result.stderr}`);
   return result.stdout;
 }
+
+function gitAtRoot(args) {
+  return run('git', ['-C', ROOT, ...args]);
+}
+
+test('checked-in bootstrap pin binds the 0.10.8 content/provenance snapshot and leaves its plugin subtree unchanged', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'installer-manifest.json'), 'utf8'));
+  assert.equal(manifest.pluginRef, RELEASE_SNAPSHOT_REF);
+  assert.equal(manifest.marketplaceRef, RELEASE_SNAPSHOT_REF);
+
+  const pluginManifest = JSON.parse(gitAtRoot([
+    'show',
+    `${RELEASE_SNAPSHOT_REF}:plugins/chengfeng-videocut/.codex-plugin/plugin.json`
+  ]));
+  const provenance = JSON.parse(gitAtRoot([
+    'show',
+    `${RELEASE_SNAPSHOT_REF}:plugins/chengfeng-videocut/.codex-plugin/update-provenance.json`
+  ]));
+  assert.equal(pluginManifest.version, RELEASE_PLUGIN_VERSION);
+  assert.equal(provenance.version, RELEASE_PLUGIN_VERSION);
+  assert.equal(provenance.immutableRef, RELEASE_CONTENT_REF);
+  gitAtRoot(['merge-base', '--is-ancestor', RELEASE_CONTENT_REF, RELEASE_SNAPSHOT_REF]);
+
+  const pluginChangesAfterSnapshot = gitAtRoot([
+    'diff',
+    '--name-only',
+    RELEASE_SNAPSHOT_REF,
+    'HEAD',
+    '--',
+    'plugins/chengfeng-videocut'
+  ]).trim();
+  assert.equal(pluginChangesAfterSnapshot, '', 'Bootstrap C must not alter the released plugin subtree.');
+
+  const readme = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
+  assert.match(readme, new RegExp('本次待发布 Plugin 是 `' + RELEASE_PLUGIN_VERSION + '`'));
+  assert.match(readme, new RegExp('`' + RELEASE_CONTENT_REF + '`'));
+  assert.match(readme, new RegExp('`' + RELEASE_SNAPSHOT_REF + '`'));
+  assert.match(readme, /stable 指向 B，main 指向 C，Bootstrap manifest 固定 B/);
+  assert.doesNotMatch(readme, /当前 `main` 候选 Plugin 是 `0\.10\.7`/);
+});
 
 function createClone(dir, { origin = ORIGIN, metadata = {} } = {}) {
   const clone = path.join(dir, 'codex-home', '.tmp', 'marketplaces', 'chengfeng-videocut');


### PR DESCRIPTION
## 候选范围

- 仅候选分支；不移动 `stable`、不更新 `main`、不创建 GitHub Release。
- A′ `a513462f65b6f50083a20ac8da6ec3c32d2ddcde`：Plugin 0.10.8 与 Runtime v0.4.8 portable 合同。
- B′ `1487e02b1c0c39ea74d079e8ce45da56bf59bc32`：不可变 provenance 快照。
- C′ `2e51611965af6e6b8baea3bfc82995b5c9e8f5ef`：Bootstrap 固定 B′，Plugin 子树与 B′ 无差异。

## 验证

- Bootstrap：22/22 通过，含 `npm pack` 安装路径与 dry-run。
- Plugin：`npm test` 通过；macOS 下 Windows 专项测试按平台跳过。
- provenance：干净 clone 中 B′ 的 inventory digest 与发布者 SHA-256 一致。
- macOS：从公开 `v0.4.8` Release、无本地 source/bin/installer/release override、独立 `CHENGFENG_VIDEOCUT_HOME` 安装；`0.4.8` 与 `doctor --json` 均通过。

## 后续门禁

在此分支派发 Windows smoke。该结果通过后仍需明确发布决策，才可考虑移动 `stable` / `main`。